### PR TITLE
Annotation display length now depends on content

### DIFF
--- a/app/src/main/java/fi/aalto/legroup/achso/annotation/Annotation.java
+++ b/app/src/main/java/fi/aalto/legroup/achso/annotation/Annotation.java
@@ -44,6 +44,8 @@ import fi.aalto.legroup.achso.util.TextSettable;
 public class Annotation extends AnnotationBase implements TextSettable, SerializableToDB {
 
     public static final long ANNOTATION_SHOW_DURATION_MILLISECONDS = 3000;
+    public static final long MINIMUM_DISPLAY_DURATION = 2000;
+    public static final long DISPLAY_DURATION_PER_CHAR = 100;
     public static final long ANNOTATION_FADE_DURATION_MILLISECONDS = 200;
     public static final int ORIGINAL_SIZE = 60;
     boolean mSelected;
@@ -101,7 +103,9 @@ public class Annotation extends AnnotationBase implements TextSettable, Serializ
         return this.mSelected;
     }
 
-    public void setSelected(boolean value) { mSelected = value; }
+    public void setSelected(boolean value) {
+        mSelected = value;
+    }
 
     public long getDuration() {
         return super.getDuration();
@@ -167,11 +171,11 @@ public class Annotation extends AnnotationBase implements TextSettable, Serializ
     }
 
     public static void drawAnnotationRect(Canvas c, Paint color, Paint shadow, Float posx,
-                                         Float posy, int wh, float scale) {
+                                          Float posy, int wh, float scale) {
         int wh2 = wh / 2;
         int tilt = wh / 8;
         int adjust = 4; //wh / 16;
-        int madjust = (int) (4 * (scale * 2) );
+        int madjust = (int) (4 * (scale * 2));
         //int madjust = (int) ((wh / 16) * (scale * 2) );
         color.setStyle(Paint.Style.STROKE);
         color.setAntiAlias(true);
@@ -224,7 +228,7 @@ public class Annotation extends AnnotationBase implements TextSettable, Serializ
             if (isSelected()) {
                 p.setStrokeWidth(0);
                 p.setShadowLayer(2, 2, 2, mColorShadow);
-                c.drawLine(posx, posy + (mSize/2) + 2, c.getWidth()/2, c.getHeight() - 54, p);
+                c.drawLine(posx, posy + (mSize / 2) + 2, c.getWidth() / 2, c.getHeight() - 54, p);
             }
 
 

--- a/app/src/main/java/fi/aalto/legroup/achso/annotation/SubtitleManager.java
+++ b/app/src/main/java/fi/aalto/legroup/achso/annotation/SubtitleManager.java
@@ -30,14 +30,13 @@ import android.widget.TextView;
 
 import java.util.HashMap;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 
 import fi.aalto.legroup.achso.R;
 
 public class SubtitleManager {
 
-    private static List<TextView> freeTextViews = new LinkedList<TextView>();
+    private static LinkedList<TextView> freeTextViews = new LinkedList<TextView>();
     private static Map<Annotation, TextView> textViewsInUse = new HashMap<Annotation, TextView>();
     private static LinearLayout subtitleContainer;
     private static LayoutInflater inflater;
@@ -52,7 +51,7 @@ public class SubtitleManager {
         if (freeTextViews.isEmpty()) {
             text = (TextView) inflater.inflate(R.layout.subtitle, subtitleContainer, false);
         } else {
-            text = freeTextViews.iterator().next();
+            text = freeTextViews.pop();
         }
 
         textViewsInUse.put(a, text);

--- a/app/src/main/java/fi/aalto/legroup/achso/database/AnnotationBase.java
+++ b/app/src/main/java/fi/aalto/legroup/achso/database/AnnotationBase.java
@@ -55,9 +55,8 @@ public class AnnotationBase implements XmlSerializable {
         mVideoId = videoid;
         mCreator = creator;
         mStartTime = starttime;
-        mDuration = duration;
         mPosition = position;
-        mText = text;
+        this.setText(text);
         mScale = scale;
         mVideoKey = (video_key != null) ? video_key : Long.toString(videoid);
     }
@@ -68,6 +67,13 @@ public class AnnotationBase implements XmlSerializable {
 
     public void setText(String text) {
         mText = text;
+
+        long length = text.length() * Annotation.DISPLAY_DURATION_PER_CHAR;
+        if (length < Annotation.MINIMUM_DISPLAY_DURATION) {
+            length = Annotation.MINIMUM_DISPLAY_DURATION;
+        }
+
+        this.mDuration = length;
     }
 
     public long getId() {

--- a/app/src/main/java/fi/aalto/legroup/achso/fragment/SemanticVideoPlayerFragment.java
+++ b/app/src/main/java/fi/aalto/legroup/achso/fragment/SemanticVideoPlayerFragment.java
@@ -459,7 +459,6 @@ public class SemanticVideoPlayerFragment extends Fragment implements SurfaceHold
     }
 
 
-
     private void pauseOnAnnotations(List<Annotation> annotationsToShow) {
         // start annotation pause mode. AnnotationPauseCounter will eventually end it.
         mStallPauseCounter = false;
@@ -469,7 +468,6 @@ public class SemanticVideoPlayerFragment extends Fragment implements SurfaceHold
         mPauseHandler = new Handler();
         mPauseHandler.postDelayed(new AnnotationPauseCounter(annotationsToShow), PAUSE_COUNTER_REFRESH_INTERVAL);
     }
-
 
 
     public void setEditableAnnotations(boolean editableAnnotations) {
@@ -740,7 +738,7 @@ public class SemanticVideoPlayerFragment extends Fragment implements SurfaceHold
                 } else { // keep dragging
 
                     // if dragging on areas covered by controllers, hide them.
-                    if (mVideoTakesAllVerticalSpace && mTitleAreaHeight+10 > event.getY()) {
+                    if (mVideoTakesAllVerticalSpace && mTitleAreaHeight + 10 > event.getY()) {
                         mController.hide();
                     } else if (mVideoTakesAllVerticalSpace && mControllerTopCoordinate - 10 < event.getY
                             ()) {
@@ -849,7 +847,7 @@ public class SemanticVideoPlayerFragment extends Fragment implements SurfaceHold
     public void onAnnotationTimerTick(long playbackPosition) {
         List<Annotation> annotations = mAnnotationSurfaceHandler.getAnnotationsAt(playbackPosition);
 
-        if ( ! annotations.isEmpty()) {
+        if (!annotations.isEmpty()) {
             pauseOnAnnotations(annotations);
         }
 
@@ -888,10 +886,15 @@ public class SemanticVideoPlayerFragment extends Fragment implements SurfaceHold
 
     private class AnnotationPauseCounter implements Runnable {
         private int counter = 0;
+        private long totalPauseTime;
         private List<Annotation> mAnnotationsToShow;
 
         public AnnotationPauseCounter(List<Annotation> annotationsToShow) {
+            totalPauseTime = 0;
             mAnnotationsToShow = annotationsToShow;
+            for (Annotation a : mAnnotationsToShow) {
+                totalPauseTime = totalPauseTime + a.getDuration();
+            }
         }
 
         @Override
@@ -902,8 +905,8 @@ public class SemanticVideoPlayerFragment extends Fragment implements SurfaceHold
             if (!mStallPauseCounter) {
                 counter += PAUSE_COUNTER_REFRESH_INTERVAL;
             }
-            if (counter < Annotation.ANNOTATION_SHOW_DURATION_MILLISECONDS && mController.isPausedForShowingAnnotation()) {
-                mController.setAnnotationPausedProgress((int) ((counter * 100) / Annotation.ANNOTATION_SHOW_DURATION_MILLISECONDS));
+            if (counter < totalPauseTime && mController.isPausedForShowingAnnotation()) {
+                mController.setAnnotationPausedProgress((int) ((counter * 100) / totalPauseTime));
                 mPauseHandler.postDelayed(this, PAUSE_COUNTER_REFRESH_INTERVAL);
             } else {
                 for (Annotation a : mAnnotationsToShow) {


### PR DESCRIPTION
Each annotation is now shown for Annotation.DISPLAY_DURATION_PER_CHAR *
text.length() or at least for Annotation.MINIMUM_DISPLAY_DURATION. This
way user should have time to read even longer comments.
