### PR TITLE
Add an example for secrets.xml.

### DIFF
--- a/app/src/main/res/values/.secrets.xml
+++ b/app/src/main/res/values/.secrets.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- This file contains all potentially sensitive information that should be kept out of our
+     version control. -->
+
+<!-- TODO: Fill in your own values and rename to secrets.xml. -->
+
+<resources>
+    <string name="google_maps_api_key" translatable="false" />
+
+    <string name="oidcClientId" translatable="false" />
+    <string name="oidcClientSecret" translatable="false" />
+
+    <string name="oidcAuthorizationServerUrl" translatable="false" />
+    <string name="oidcTokenServerUrl" translatable="false" />
+    <string name="oidcUserInfoUrl" translatable="false" />
+
+    <!-- This URL doesn't really have a use with native apps and basically just signifies the end
+         of the authorisation process. It doesn't have to be a real URL. -->
+    <string name="oidcRedirectUrl" translatable="false" />
+
+    <!-- The `offline_access` scope enables us to request Refresh Tokens, so we don't have to bug
+         the user all the time. Some servers might have an `offline` scope instead. -->
+    <string-array name="oidcScopes" translatable="false">
+        <item>openid</item>
+        <item>email</item>
+        <item>profile</item>
+        <item>offline_access</item>
+    </string-array>
+
+    <string name="sssUrl" translatable="false" />
+    <string name="clvitra2Url" translatable="false" />
+
+    <string name="feedbackServerKey" translatable="false" />
+    <string name="feedbackServerUrl" translatable="false" />
+</resources>


### PR DESCRIPTION
The file needs to be hidden since that's the only way to avoid
duplicate resource errors.
