### PR TITLE
Keep mp4parser classes.

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -55,6 +55,10 @@
 -dontwarn com.actionbarsherlock.**
 
 #####
+# mp4parser
+-keep com.coremedia.iso.boxes.** { *; }
+
+#####
 # Guava
 -dontwarn sun.misc.Unsafe
 -dontwarn com.google.common.collect.MinMaxPriorityQueue


### PR DESCRIPTION
If a box has been removed during compilation and is needed at runtime, the application will crash.