### PR TITLE
Split Google Play Services dependency.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,7 +61,9 @@ dependencies {
     compile 'com.google.guava:guava:18.0'
 
     // Google Play Services APIs
-    compile 'com.google.android.gms:play-services:6.5.87'
+    compile 'com.google.android.gms:play-services-base:6.5.87'
+    compile 'com.google.android.gms:play-services-maps:6.5.87'
+    compile 'com.google.android.gms:play-services-location:6.5.87'
 
     // OAuth2 library for OpenID Connect
     compile('com.google.oauth-client:google-oauth-client:1.18.0-rc') {


### PR DESCRIPTION
Only brings in what’s required.