### PR TITLE
Pass a URI, not a file, as EXTRA_OUTPUT.

### DIFF
--- a/app/src/main/java/fi/aalto/legroup/achso/browsing/BrowserActivity.java
+++ b/app/src/main/java/fi/aalto/legroup/achso/browsing/BrowserActivity.java
@@ -194,15 +194,16 @@ public class BrowserActivity extends ActionBarActivity {
         videoBuilder = VideoCreatorService.build();
 
         File videoFile = VideoCreatorService.getStorageVideoFile(videoBuilder);
+        Uri videoUri = Uri.fromFile(videoFile);
 
         // Some camera apps (looking at you, Samsung) don't return any data if the EXTRA_OUTPUT
         // flag is set. The storage file is a good fallback in case the camera app doesn't give us
         // a URI.
-        videoBuilder.setVideoUri(Uri.fromFile(videoFile));
+        videoBuilder.setVideoUri(videoUri);
 
         Intent intent = new Intent(MediaStore.ACTION_VIDEO_CAPTURE);
 
-        intent.putExtra(MediaStore.EXTRA_OUTPUT, videoFile);
+        intent.putExtra(MediaStore.EXTRA_OUTPUT, videoUri);
 
         startActivityForResult(intent, REQUEST_RECORD_VIDEO);
     }


### PR DESCRIPTION
The intent does accept a File since it’s Serializable, but the receiver
gets a Parcelable. This results in the following (caught) exception:

“Key output expected Parcelable but value was a java.io.File.  The
default value &lt;null&gt; was returned.”