### PR TITLE
Assume that videos without a URI scheme are local.

### DIFF
--- a/app/src/main/java/fi/aalto/legroup/achso/playback/utilities/VideoOrientationPatcher.java
+++ b/app/src/main/java/fi/aalto/legroup/achso/playback/utilities/VideoOrientationPatcher.java
@@ -61,7 +61,11 @@ public final class VideoOrientationPatcher implements MediaCodecVideoTrackRender
             return;
         }
 
-        if (!videoUri.getScheme().trim().equalsIgnoreCase("file")) {
+        // Assuming that URIs without a scheme are local.
+        String scheme = videoUri.getScheme();
+        boolean isLocal = (scheme == null || scheme.equalsIgnoreCase("file"));
+
+        if (!isLocal) {
             throw new IllegalArgumentException("Only file:// URIs are supported.");
         }
 


### PR DESCRIPTION
Prevents a crash on some of our test devices that have really old videos.