### PR TITLE
Relax exception type in catch block.

### DIFF
--- a/app/src/main/java/fi/aalto/legroup/achso/playback/utilities/FrameworkOrientationReader.java
+++ b/app/src/main/java/fi/aalto/legroup/achso/playback/utilities/FrameworkOrientationReader.java
@@ -31,7 +31,7 @@ public final class FrameworkOrientationReader {
             retriever.setDataSource(context, Uri.fromFile(file));
 
             return Integer.parseInt(retriever.extractMetadata(METADATA_KEY_VIDEO_ROTATION));
-        } catch (NumberFormatException e) {
+        } catch (IllegalArgumentException e) {
             return -1;
         } finally {
             if (retriever != null) {


### PR DESCRIPTION
Now also catches an `IllegalArgumentException` from `MediaMetadataRetriever#setDataSource`.